### PR TITLE
Django version updates

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -2,6 +2,6 @@
 from .predicate import P
 from .predicate import PredicateQuerySet
 
-__version__ = '1.4.0'
+__version__ = '2.0.0'
 __all__ = ['P', 'PredicateQuerySet']
 

--- a/predicate/lookup_utils.py
+++ b/predicate/lookup_utils.py
@@ -1,8 +1,6 @@
 import datetime
 import operator
 
-import django
-
 import re
 
 from django.db import models
@@ -207,9 +205,6 @@ def get_field_and_accessor(instance_or_model, lookup_part):
     if lookup_part == 'pk':
         field = instance_or_model._meta.pk
         direct = True
-    elif django.VERSION < (1, 8):
-        field, model, direct, m2m = instance_or_model._meta.get_field_by_name(lookup_part)
-    else:
-        field = instance_or_model._meta.get_field(lookup_part)
-        direct = not field.auto_created or field.concrete
+    field = instance_or_model._meta.get_field(lookup_part)
+    direct = not field.auto_created or field.concrete
     return field, (lookup_part if direct else field.get_accessor_name())

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,11 @@
 # Requirements needed for running the test suite.
 
 coverage
-django-nose==1.4.2
+
+# Use the current HEAD for 1.10 support. This can be replaced with the pypi version once
+# this commit is included on pypi.
+-e git+https://github.com/django-nose/django-nose.git@9ecfc4d8fa78400a32ea2b544c38b1661ddb0048#egg=django-nose
+
 nose==1.3.7
 psycopg2
 mock

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -160,3 +160,4 @@ LOGGING = {
 }
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+USE_TZ = False

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@ ignore=W503
 
 [tox]
 install_command = pip install {opts} {packages}
-envlist = lint,clean,py27-{1.7,1.8,1.9}-{postgres,sqlite},py35-{1.8,1.9}-{postgres,sqlite},stats
+envlist = lint,clean,py27-{1.8,1.9,1.10}-{postgres,sqlite},py35-{1.8,1.9}-{postgres,sqlite},stats
 
 [tox:travis]
-2.7 = py27-{1.7,1.8,1.9}-{postgres,sqlite}, stats
-3.5 = py35-{1.8,1.9}-{postgres,sqlite}, lint, stats
+2.7 = py27-{1.8,1.9,1.10}-{postgres,sqlite}, stats
+3.5 = py35-{1.8,1.9,1.10}-{postgres,sqlite}, lint, stats
 
 [testenv]
 passenv = LANG POSTGRES_USER POSTGRES_PASSWORD
@@ -26,9 +26,9 @@ basepython =
     py27: python2.7
 deps =
   -r{toxinidir}/requirements-test.txt
-  1.7: Django>=1.7,<1.8
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
+  1.10: Django==1.10a1
 setenv =
   TOXENV={envname}
   sqlite: DB_BACKEND=sqlite3


### PR DESCRIPTION
This PR drops support for Django 1.7, which should support #23. It also adds Django 1.10a1 to the test suite, which passed with no required changes to code, just a few minor changes to the test suite. I'll update the version to the full release when it is released.

I also bumped the version number to 2.0.0 in preparation for a release which breaks backwards compatibility. I don't think it's worth cutting a release for this version yet, since no new functionality was added.