### PR TITLE
Update build matrix and add explicit support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 install: pip install tox-travis
 script: tox
 env:

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -15,7 +15,7 @@ class Base(models.Model):
 
 @nottest
 class TestObj(Base):
-    parent = models.ForeignKey('self', related_name='children', null=True)
+    parent = models.ForeignKey('self', related_name='children', null=True, on_delete=models.CASCADE)
     m2ms = models.ManyToManyField(
         'testapp.M2MModel', related_name='test_objs')
 
@@ -33,13 +33,13 @@ class M2MModel(Base):
 
 class OneToOneModel(Base):
     test_obj = models.OneToOneField(
-        TestObj, null=True)
+        TestObj, null=True, on_delete=models.CASCADE)
 
 
 class CustomRelatedNameOneToOneModel(Base):
     test_obj = models.OneToOneField(
-        TestObj, related_name='custom_one_to_one', null=True)
+        TestObj, related_name='custom_one_to_one', null=True, on_delete=models.CASCADE)
 
 
 class ForeignKeyModel(Base):
-    test_obj = models.ForeignKey(TestObj, null=True)
+    test_obj = models.ForeignKey(TestObj, null=True, on_delete=models.CASCADE)

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,12 @@ ignore=W503
 
 [tox]
 install_command = pip install {opts} {packages}
-envlist = lint,clean,py27-{1.8,1.9,1.10}-{postgres,sqlite},py35-{1.8,1.9}-{postgres,sqlite},stats
+envlist = lint,clean,py27-{1.9,1.11}-{postgres,sqlite},{py35,py36}-{1.9,1.11,2.0}-{postgres,sqlite},stats
 
 [tox:travis]
-2.7 = py27-{1.8,1.9,1.10}-{postgres,sqlite}, stats
-3.5 = py35-{1.8,1.9,1.10}-{postgres,sqlite}, lint, stats
+2.7 = py27-{1.9,1.11}-{postgres,sqlite}, stats
+3.5 = py35-{1.9,1.11,2.0}-{postgres,sqlite}, lint, stats
+3.6 = py36-{1.9,1.11,2.0}-{postgres,sqlite}, lint, stats
 
 [testenv]
 passenv = LANG POSTGRES_USER POSTGRES_PASSWORD
@@ -19,17 +20,17 @@ commands =
   {envbindir}/coverage run -p --omit="*tests*" --source=predicate --branch \
     setup.py test
 basepython =
-    lint: python3.5
-    clean: python2.7
-    stats: python2.7
+    lint: python3.6
+    clean: python3.6
+    stats: python3.6
     py35: python3.5
+    py36: python3.6
     py27: python2.7
 deps =
   -r{toxinidir}/requirements-test.txt
-  1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
-  1.10: Django>=1.10,<1.11
   1.11: Django>=1.11,<2
+  2.0: Django>=2.0,<2.1
 setenv =
   TOXENV={envname}
   sqlite: DB_BACKEND=sqlite3

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint,clean,py27-{1.9,1.11}-{postgres,sqlite},{py35,py36}-{1.9,1.11,2.0
 
 [tox:travis]
 2.7 = py27-{1.9,1.11}-{postgres,sqlite}, stats
-3.5 = py35-{1.9,1.11,2.0}-{postgres,sqlite}, lint, stats
+3.5 = py35-{1.9,1.11,2.0}-{postgres,sqlite}, stats
 3.6 = py36-{1.9,1.11,2.0}-{postgres,sqlite}, lint, stats
 
 [testenv]
@@ -21,8 +21,8 @@ commands =
     setup.py test
 basepython =
     lint: python3.6
-    clean: python3.6
-    stats: python3.6
+    clean: python2.7
+    stats: python2.7
     py35: python3.5
     py36: python3.6
     py27: python2.7


### PR DESCRIPTION
This PR adds support for Django 2.0 and Python 3.6. No code changes were required, only changes to tests, so this does not require a release.

## Testing
Unit tests pass locally. I'll merge if the travis tests pass without errors.